### PR TITLE
Convert json to list for updating Glue resources in SDLF

### DIFF
--- a/infrastructure/glue_tagger_cr/handler.py
+++ b/infrastructure/glue_tagger_cr/handler.py
@@ -6,6 +6,7 @@ SPDX-License-Identifier: MIT-0
 import boto3
 import logging
 from crhelper import CfnResource
+import json
 
 
 cf = boto3.resource('cloudformation')
@@ -47,7 +48,10 @@ def get_tags_from_stack(stack_id):
 
 def get_tags_from_props(tags_from_props):
     logger.info(f'Tags from props {tags_from_props}')
-    return tags_from_props
+    try:
+        return(json.loads(tags_from_props))
+    except ValueError as e:
+        return tags_from_props
 
 
 def get_tags(tags_from_props, tags_from_stack):


### PR DESCRIPTION
*Issue #, if available:*
Currently in [SDLF](https://github.com/awslabs/aws-serverless-data-lake-framework/) tags.json files are used to update resources in Cloudformation in stack level, since updating Glue resources was not possible we are using this Repo to update but it's only updating if Tags values are List, so using same parameter for both[ CloudFormation stack level tagging ](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html) and GlueTagger was not possible, therefore this PR will convert input to a list if it's json which would help us to update both gluetagger and cloudformation stack level tags with same parameter.

*Description of changes:*
To fix this issue, json library added and input value is converted to list if it's json string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
